### PR TITLE
Support custom schema property

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,12 +20,13 @@
   UserSchema.plugin(gravatar);
 
   // or... provide some default options for plugin
+  // note: var options = { property: "primaryEmail" ... should you want a different property than email.
   var options = { secure: true, default: "retro", size: 245 };
   UserSchema.plugin(gravatar, options);
 
   // ...
 
-  var author = new User({ email: 'jorge@ups.com'});
+  var author = new User({ email: 'jorge@ups.com' });
 
   // retrieves a normal gravatar url
   author.gravatar()
@@ -34,7 +35,7 @@
   // retrieves a secure (https) gravatar url
   author.gravatar({ secure: true })
   // out: 'https://secure.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
-  
+
   // sets size to 150px width and height
   author.gravatar({ size: 150 });
   // out: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=150'
@@ -46,6 +47,7 @@
 
 ## API options list
 The following are the list of options allowed for `.gravatar()` model method.
+* `property`: Schema property, defaults to `email`
 * `secure`: Compiles a secure url for gravatars. Check `gravatar.com` [docs](http://en.gravatar.com/site/implement/images/#secure-images) for more info.
 * `email`: Returns a gravatar url for a different email than the model's.
 * `size`: Determines the size of the image delivered by `gravatar.com`. Check `gravatar.com` [docs](http://en.gravatar.com/site/implement/images/#size) for more info.

--- a/Readme.md
+++ b/Readme.md
@@ -12,42 +12,52 @@
 
 ## Usage example
 
+Setup
+
 ```js
-  var gravatar = require('mongoose-gravatar');
-  var UserSchema = new Schema({ email: String });
+var gravatar = require('mongoose-gravatar');
+var UserSchema = new Schema({ email: String });
 
-  // Extend User's Schema with gravatar plugin
-  UserSchema.plugin(gravatar);
+// Extend User's Schema with gravatar plugin
+UserSchema.plugin(gravatar);
 
-  // or... provide some default options for plugin
-  // note: var options = { property: "primaryEmail" ... should you want a different property than email.
-  var options = { secure: true, default: "retro", size: 245 };
-  UserSchema.plugin(gravatar, options);
+// or... provide some default options for plugin
+UserSchema.plugin(gravatar, { secure: true, default: "retro", size: 245 });
 
-  // ...
+// or... custom schema property
+UserSchema = new Schema({ primaryEmail: String });
+UserSchema.plugin(gravatar, { property: 'primaryEmail' });
 
-  var author = new User({ email: 'jorge@ups.com' });
-
-  // retrieves a normal gravatar url
-  author.gravatar()
-  // out: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
-
-  // retrieves a secure (https) gravatar url
-  author.gravatar({ secure: true })
-  // out: 'https://secure.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
-
-  // sets size to 150px width and height
-  author.gravatar({ size: 150 });
-  // out: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=150'
-
-  // With provided options at plugin level...
-  author.gravatar()
-  // out: https://secure.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?d=retro&s=245
+// ...
 ```
+
+Retrieving Gravatar from User Model
+
+```js
+var author = new User({ email: 'jorge@ups.com' });
+
+// retrieves a normal gravatar url
+author.gravatar()
+// out: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
+
+// retrieves a secure (https) gravatar url
+author.gravatar({ secure: true })
+// out: 'https://secure.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8'
+
+// sets size to 150px width and height
+author.gravatar({ size: 150 });
+// out: 'http://www.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?s=150'
+
+// With provided options at plugin level...
+author.gravatar()
+// out: https://secure.gravatar.com/avatar/23463b99b62a72f26ed677cc556c44e8?d=retro&s=245
+```
+
+## Plugin specific options
+* `property`: Schema property, optional, defaults to `email`
 
 ## API options list
 The following are the list of options allowed for `.gravatar()` model method.
-* `property`: Schema property, defaults to `email`
 * `secure`: Compiles a secure url for gravatars. Check `gravatar.com` [docs](http://en.gravatar.com/site/implement/images/#secure-images) for more info.
 * `email`: Returns a gravatar url for a different email than the model's.
 * `size`: Determines the size of the image delivered by `gravatar.com`. Check `gravatar.com` [docs](http://en.gravatar.com/site/implement/images/#size) for more info.

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function plugin(schema, options) {
  */
 
 function gravatar(settings) {
-  var email = settings.email || this[settings.property] || "example@example.com";
+  var email = settings.email || this[(settings.property || 'email')] || "example@example.com";
   var host = (settings.secure ? "secure" : "www") + ".gravatar.com";
   var protocol = settings.secure ? "https" : "http";
   var pathname = "/avatar/" + md5(email);

--- a/index.js
+++ b/index.js
@@ -15,7 +15,10 @@ var keys = Object.keys;
  */
 
 module.exports = function plugin(schema, options) {
-  options = options || {};
+  options = options || {
+    property: 'email'
+  };
+
   schema.methods.gravatar = function(settings) {
     settings = settings || {};
     complete(settings, options);
@@ -33,7 +36,7 @@ module.exports = function plugin(schema, options) {
  */
 
 function gravatar(settings) {
-  var email = settings.email || this.email || "example@example.com";
+  var email = settings.email || this[settings.property] || "example@example.com";
   var host = (settings.secure ? "secure" : "www") + ".gravatar.com";
   var protocol = settings.secure ? "https" : "http";
   var pathname = "/avatar/" + md5(email);
@@ -42,7 +45,7 @@ function gravatar(settings) {
     d: settings.default,
     f: settings.forcedefault,
     r: settings.rating
-  };  
+  };
 
   return url.format({
     protocol: protocol,

--- a/test/index.js
+++ b/test/index.js
@@ -11,23 +11,26 @@ function md5(word) {
 // Connect mongoose to mongodb
 mongoose.connect('mongodb://localhost/mongoose_test_gravatar');
 
-// Define User and Admin schemas to extend with gravatar plugin
+// Define schemas to extend with gravatar plugin
 var UserSchema = new Schema({ email: String });
 var AdminSchema = new Schema({ email: String });
+var TesterSchema = new Schema({ primaryEmail: String });
 
-// Extend User and Admin schemas with gravatar plugin
-var options = { default: "mm" };
+// Extend schemas with gravatar plugin
 UserSchema.plugin(gravatar);
-AdminSchema.plugin(gravatar, options);
+AdminSchema.plugin(gravatar, { default: "mm" });
+TesterSchema.plugin(gravatar, { property: "primaryEmail" });
 
-// Register User Model on top of UserSchema
+// Register Models
 var User = mongoose.model('User', UserSchema);
 var Admin = mongoose.model('Admin', AdminSchema);
+var Tester = mongoose.model('Tester', TesterSchema);
 
 describe('mongoose-gravatar', function () {
   var email = "";
   var user = {};
   var admin = {};
+  var tester = {};
   var url = "";
 
   before(function (done) {
@@ -45,11 +48,12 @@ describe('mongoose-gravatar', function () {
     email = "example@example.com";
     user = new User({ email: email });
     admin = new Admin({ email: email });
+    tester = new Tester({ primaryEmail: email });
     url = "http://www.gravatar.com/avatar/" + md5(email);
     done();
   });
 
-  describe('.gravatar()', function() {  
+  describe('.gravatar()', function() {
     it('should build a base gravatar url without params', function(done) {
       assert.equal(url, user.gravatar());
       done();
@@ -68,7 +72,12 @@ describe('mongoose-gravatar', function () {
 
       url = "http://www.gravatar.com/avatar/" + md5(email);
 
-      assert.equal(url, user.gravatar())
+      assert.equal(url, user.gravatar());
+      done();
+    });
+
+    it('should support different schema properties', function(done) {
+      assert.equal(url, tester.gravatar());
       done();
     });
 
@@ -77,7 +86,7 @@ describe('mongoose-gravatar', function () {
       assert.equal(url, admin.gravatar());
       done();
     });
-  })
+  });
 
   describe('.gravatar(params)', function() {
     it('should use secure url', function (done) {
@@ -117,4 +126,3 @@ describe('mongoose-gravatar', function () {
   });
 
 });
-


### PR DESCRIPTION
Our schema uses `primaryEmail` instead of `email` and since the code is pre-existing this makes it difficult for us to change over, however, by changing the module to allow changing the property we no longer need to have a custom plugin to do essentially what this plugin does.
