### PR TITLE
Fix delete memory leak, jshint cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,14 +13,13 @@ var keys = Object.keys;
  * @param {Object} options
  * @api public
  */
-
-module.exports = function plugin(schema, options) {
+module.exports = function plugin (schema, options) {
   options = options || {};
-  schema.methods.gravatar = function(settings) {
+  schema.methods.gravatar = function (settings) {
     settings = settings || {};
-    complete(settings, options);
+    merge(settings, options);
     return gravatar.call(this, settings);
-  }
+  };
 };
 
 /**
@@ -31,8 +30,7 @@ module.exports = function plugin(schema, options) {
  * @return {String} gravatar's API image `url`
  * @api private
  */
-
-function gravatar(settings) {
+function gravatar (settings) {
   var email = settings.email || this.email || "example@example.com";
   var host = (settings.secure ? "secure" : "www") + ".gravatar.com";
   var protocol = settings.secure ? "https" : "http";
@@ -42,7 +40,7 @@ function gravatar(settings) {
     d: settings.default,
     f: settings.forcedefault,
     r: settings.rating
-  };  
+  };
 
   return url.format({
     protocol: protocol,
@@ -50,7 +48,7 @@ function gravatar(settings) {
     pathname: pathname,
     query: clear(params)
   });
-};
+}
 
 /**
  * Creates an MD5 enctryption hash
@@ -60,9 +58,8 @@ function gravatar(settings) {
  * @return {String} hashed `word`
  * @api private
  */
-
-function md5(word) {
-  return crypto.createHash('md5').update(word).digest("hex");
+function md5 (word) {
+  return crypto.createHash("md5").update(word).digest("hex");
 }
 
 /**
@@ -73,36 +70,40 @@ function md5(word) {
  * @return {Object} reduced object
  * @api private
  */
-
 function clear (obj) {
-  var names = keys(obj);
-  names.forEach(function(n) {
-    if (null == obj[n]) delete obj[n];
+  var output = {};
+
+  keys(obj).forEach(function (key) {
+    if (obj[key] != null) {
+      output[key] = obj[key];
+    }
   });
-  return obj;
+
+  return output;
 }
 
 /**
- * Completes missing keys in `settings` object
- * from the ones comming from `options` object
+ * Merge missing keys in `settings` object
+ * from the ones coming from `options` object
  * as default values for `gravatar` function.
  *
  * @param {Object} settings
  * @param {Object} options
- * @return {Objsect} completed `settings` object
+ * @return {Objsect} merged `settings` object
  * @api private
  */
-
-function complete (settings, options) {
+function merge (settings, options) {
   var defaults = keys(options);
+  var length = defaults.length;
+  var i = 0;
 
-  for (var i = 0; i < defaults.length; i++) {
+  for (; i < length; i++) {
     var key = defaults[i];
 
-    if (null == settings[key] && null != options[key]) {
+    if (settings[key] == null && options[key] != null) {
       settings[key] = options[key];
     }
-  };
+  }
 
   return settings;
-};
+}

--- a/index.js
+++ b/index.js
@@ -35,18 +35,18 @@ function gravatar (settings) {
   var host = (settings.secure ? "secure" : "www") + ".gravatar.com";
   var protocol = settings.secure ? "https" : "http";
   var pathname = "/avatar/" + md5(email);
-  var params = {
+  var params = clear({
     s: settings.size,
     d: settings.default,
     f: settings.forcedefault,
     r: settings.rating
-  };
+  });
 
   return url.format({
     protocol: protocol,
     host: host,
     pathname: pathname,
-    query: clear(params)
+    query: params
   });
 }
 
@@ -73,12 +73,14 @@ function md5 (word) {
 function clear (obj) {
   var output = {};
 
+  // Transfer properties to new object
   keys(obj).forEach(function (key) {
     if (obj[key] != null) {
       output[key] = obj[key];
     }
   });
 
+  // Output new object
   return output;
 }
 

--- a/index.js
+++ b/index.js
@@ -76,12 +76,14 @@ function md5 (word) {
 function clear (obj) {
   var output = {};
 
+  // Transfer properties to new object
   keys(obj).forEach(function (key) {
     if (obj[key] != null) {
       output[key] = obj[key];
     }
   });
 
+  // Output new object
   return output;
 }
 

--- a/index.js
+++ b/index.js
@@ -13,17 +13,16 @@ var keys = Object.keys;
  * @param {Object} options
  * @api public
  */
-
-module.exports = function plugin(schema, options) {
+module.exports = function plugin (schema, options) {
   options = options || {
     property: 'email'
   };
 
-  schema.methods.gravatar = function(settings) {
+  schema.methods.gravatar = function (settings) {
     settings = settings || {};
-    complete(settings, options);
+    merge(settings, options);
     return gravatar.call(this, settings);
-  }
+  };
 };
 
 /**
@@ -34,26 +33,25 @@ module.exports = function plugin(schema, options) {
  * @return {String} gravatar's API image `url`
  * @api private
  */
-
-function gravatar(settings) {
+function gravatar (settings) {
   var email = settings.email || this[(settings.property || 'email')] || "example@example.com";
   var host = (settings.secure ? "secure" : "www") + ".gravatar.com";
   var protocol = settings.secure ? "https" : "http";
   var pathname = "/avatar/" + md5(email);
-  var params = {
+  var params = clear({
     s: settings.size,
     d: settings.default,
     f: settings.forcedefault,
     r: settings.rating
-  };
+  });
 
   return url.format({
     protocol: protocol,
     host: host,
     pathname: pathname,
-    query: clear(params)
+    query: params
   });
-};
+}
 
 /**
  * Creates an MD5 enctryption hash
@@ -63,9 +61,8 @@ function gravatar(settings) {
  * @return {String} hashed `word`
  * @api private
  */
-
-function md5(word) {
-  return crypto.createHash('md5').update(word).digest("hex");
+function md5 (word) {
+  return crypto.createHash("md5").update(word).digest("hex");
 }
 
 /**
@@ -76,36 +73,40 @@ function md5(word) {
  * @return {Object} reduced object
  * @api private
  */
-
 function clear (obj) {
-  var names = keys(obj);
-  names.forEach(function(n) {
-    if (null == obj[n]) delete obj[n];
+  var output = {};
+
+  keys(obj).forEach(function (key) {
+    if (obj[key] != null) {
+      output[key] = obj[key];
+    }
   });
-  return obj;
+
+  return output;
 }
 
 /**
- * Completes missing keys in `settings` object
- * from the ones comming from `options` object
+ * Merge missing keys in `settings` object
+ * from the ones coming from `options` object
  * as default values for `gravatar` function.
  *
  * @param {Object} settings
  * @param {Object} options
- * @return {Objsect} completed `settings` object
+ * @return {Objsect} merged `settings` object
  * @api private
  */
-
-function complete (settings, options) {
+function merge (settings, options) {
   var defaults = keys(options);
+  var length = defaults.length;
+  var i = 0;
 
-  for (var i = 0; i < defaults.length; i++) {
+  for (; i < length; i++) {
     var key = defaults[i];
 
-    if (null == settings[key] && null != options[key]) {
+    if (settings[key] == null && options[key] != null) {
       settings[key] = options[key];
     }
-  };
+  }
 
   return settings;
-};
+}


### PR DESCRIPTION
Fixes memory leak by using `delete` keyword to remove properties from an object, thus turning it into a _slow object_ and causing memory gain over time instead of being GC'd properly, instead we convert to a new object, avoiding lingering references and memory leak.

Other fixes are Jshint / string consistency, as well some grammatical fixes.
